### PR TITLE
Add health check endpoint with test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app app
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 # redesigned-octo-barnacle
+
+This repository contains a simple FastAPI application that can be containerized and deployed on Kubernetes.
+The API provides a root greeting and a `/health` endpoint for basic health checks.
+
+## Development
+
+Install dependencies and run the tests:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+Run the application locally:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Docker
+
+Build the Docker image:
+
+```bash
+docker build -t my-api-image .
+```
+
+## Kubernetes
+
+Apply the deployment and service manifests:
+
+```bash
+kubectl apply -f k8s/deployment.yaml
+```
+
+Update `k8s/deployment.yaml` with the correct image name before deploying.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, World!"}
+
+
+@app.get("/health")
+def health_check():
+    return {"status": "ok"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - name: api
+        image: your-docker-image
+        ports:
+        - containerPort: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+spec:
+  selector:
+    app: api
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8000
+  type: ClusterIP

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_read_root():
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello, World!"}
+
+
+def test_health_check():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- add a `/health` route returning a simple status response
- cover the new endpoint with a test and document it in the README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68a4bcdda638832aae36b578f110d1fc