### PR TITLE
Add CI workflow for testing and deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: pytest
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/login-action@v2
+        with:
+          registry: ${{ secrets.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+      - name: Build Docker image
+        run: docker build -t ${{ secrets.REGISTRY }}/${{ github.repository }}:${{ github.sha }} .
+      - name: Push Docker image
+        run: docker push ${{ secrets.REGISTRY }}/${{ github.repository }}:${{ github.sha }}
+      - uses: azure/setup-kubectl@v3
+      - name: Configure kubectl
+        run: |
+          mkdir -p $HOME/.kube
+          echo "${KUBE_CONFIG}" | base64 --decode > $HOME/.kube/config
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+      - name: Deploy to Kubernetes
+        run: kubectl apply -f k8s/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pytest
+httpx


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for testing on push and PR
- include optional deploy job that builds/pushes Docker image and applies k8s manifests
- include httpx in requirements for FastAPI TestClient

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68a4c39fa474832a9dbf97996453d94e